### PR TITLE
add code of conduct and improve-this-page links to navbar

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -11,6 +11,8 @@
             </button>
             <a class="navbar-brand" href="https://neic.no">NeIC</a>
             <a class="navbar-brand" href="https://coderefinery.org">CodeRefinery</a>
+            <a class="navbar-brand" href="https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html">Code of Conduct</a>
+            <a class="navbar-brand" href="{{site.github.repository_url}}">Improve this page</a>
         </div>
 
         <!-- collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
next to NeIC and CodeRefinery links in the navigation bar there will now be "Code of Conduct" and "Improve this page" links
example:
![screenshot](https://user-images.githubusercontent.com/10846818/72810091-31011100-3c5d-11ea-910a-5d8596d8725c.png)
