### PR TITLE
installation: brief note about git configuration

### DIFF
--- a/left_column.md
+++ b/left_column.md
@@ -35,7 +35,8 @@ packages need to be installed as detailed on the Python installation page.
 
 - [Bash](https://coderefinery.github.io/installation/bash/)
 - [Editor](https://coderefinery.github.io/installation/editors/)
-- [Git](https://coderefinery.github.io/installation/git/)
+- [Git](https://coderefinery.github.io/installation/git/), including
+  some configuration
 - [(optional) Visual diff tools](https://coderefinery.github.io/installation/difftools/)
 - [Python](https://coderefinery.github.io/installation/python/)
 - [Jupyter and JupyterLab](https://coderefinery.github.io/installation/jupyter)


### PR DESCRIPTION
- We have enough problems with git configuration not being done, this
  is a very brief note that you can't just install git, you need to
  configure it.
- This isn't exactly the right place to fix it, so I'm happy to reject
  this and make this note somewhere else.