### PR TITLE
config: Remove duplicate slash from navigation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 # The URL the site will be built for
 
-# change this:
+# change this (end in '/'):
 base_url = "https://coderefinery.github.io/template-workshop-webpage/"
 
 title = "Replace this title in config.toml"
@@ -23,11 +23,11 @@ external_links_target_blank = true
 [extra]
 
 navigation = [
-    { name = "Schedule", path = "/" },
-    { name = "Who the course is for", path = "/audience/" },
-    { name = "How to join", path = "/join/" },
-    { name = "Requirements", path = "/requirements/" },
-    { name = "Q&A", path = "/questions/" },
+    { name = "Schedule", path = "" },
+    { name = "Who the course is for", path = "audience/" },
+    { name = "How to join", path = "join/" },
+    { name = "Requirements", path = "requirements/" },
+    { name = "Q&A", path = "questions/" },
     { name = "Code of Conduct", path = "https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html" },
     { name = "Improve this page", path = "https://github.com/coderefinery/template-workshop-webpage" }
 ]


### PR DESCRIPTION
- Standardize in ending the workshop URL in slash
- Built locally and seems to work
- Review: general check