### PR TITLE
templates/base: Use relative links instead of absolute links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -61,7 +61,7 @@
                 {% if link.path is containing("http") %}
                   <a class="nav-link" href="{{ link.path | safe }}">{{ link.name }}</a>
                 {% else %}
-                  <a class="nav-link" href="{{ config.base_url | safe }}{{ link.path | safe }}">{{ link.name }}</a>
+                  <a class="nav-link" href="{% if current_path != "/"%}../{%endif%}{{link.path|safe}}">{{ link.name }}</a>
                 {% endif %}
               {% endfor %}
             </ul>


### PR DESCRIPTION
- This is a hack to make navigation work with relative links, instead
  of absolute links.

- For example, you don't need to configure a base_url in any Sphinx
  project: it makes everything relative, so it can be viewed anywhere.
  But it seems most markdown-based site generators like to use
  absolute links (probably a historical artifact of them generating
  pages, without an overall "website"-concept.)

- This switches the main navagation links to relative.  It works for
  '/' and '/blah/', but would fail at '/blah/blah/' URLs.  It's a
  hack, ideally this would be done at the site generator level.

- You would think this could be done using the template get_url
  function:
  https://www.getzola.org/documentation/templates/overview/#get-url ,
  but I wasn't able to make that work (I couldn't pass a variable to
  another function, it could only take string literals).  I didn't try
  very hard though, if someone can make that work, it would be a
  better solution.  But does that also embed base_url, making it not
  work?

- This only makes the main navgation links relative.  All other assets
  would keep the hard-coded paths (because they are still there in the
  templates).  Thus, the base_url should still be set, but it's
  slightly less bad when you are building and viewing it locally as a
  test.  If someone forgets to set base_url on a fork, it will apper
  to work but be loading the assets from the template (which could
  cause breakage later).  Who knows if base_url is embedded in other
  more significant places.

- Review

  - Others should do due dilligence and try to find a more proper way
    of doing this.
  - There should be a low threshold to rejecting this.