### PR TITLE
content/volunteer: Add page dedicated to exercise leaders

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,7 +29,7 @@ navigation = [
     { name = "Requirements", path = "requirements/" },
     { name = "Q&A", path = "questions/" },
     { name = "Code of Conduct", path = "https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html" },
-    { name = "Improve this page", path = "https://github.com/coderefinery/template-workshop-webpage" }
+    { name = "Volunteer", path = "volunteer/" }
 ]
 
 twitter_image = "https://raw.githubusercontent.com/coderefinery/coderefinery.org/main/content/logo/coderefinery.png"

--- a/content/_index.md
+++ b/content/_index.md
@@ -21,7 +21,7 @@ breakout rooms.  This will also be streamed MOOC-style via
 This is an informal and interactive event with type-along lessons,
 live coding, and exercises. Learners are divided into exercise teams for
 interactivity - register with a friend!  If you feel a bit more
-confident in the material, you can register as an exercise leader.
+confident in the material, you can [register as an exercise leader](volunteer/).
 
 **Before signing** up please also read
 [this privacy note about tools/services we use](requirements/#privacy-and-tools-online-services).
@@ -96,6 +96,6 @@ The schedule includes frequent breaks.
 
 #### Helpers
 
-([Tips for
-helpers](https://coderefinery.github.io/manuals/helping-and-teaching/)).
+[Be a helper](volunteer/)
+
 - TBA

--- a/content/audience.md
+++ b/content/audience.md
@@ -43,4 +43,5 @@ Do you know some of the topics, but want to review them, why not
 attend as an exercise leader?  You don't need to be an expert: if you
 have been through CodeRefinery once or have some familiarity with the
 topics, and you are confident to call a helper when needed, then you
-have all it takes to lead a team to success.
+have all it takes to lead a team to success.  [Read more
+here](../volunteer/)

--- a/content/join.md
+++ b/content/join.md
@@ -28,11 +28,6 @@ is a very interactive workshop.
 **Why should I come as a team?**  If you will work together later,
   learning the tools at the same time is a great way to do it.
 
-**Am I good enough to be a helper?**  If you are asking this
-  question, probably you are.  You should have some familiarity with
-  git, provide some initial advice on obvious error messages, and
-  be able to call us for advanced help when it's needed.
-
 **How does the waiting list work?**  Anyone can register, but you go to
   the waiting list until we can be sure we have enough helpers.  We'll
   continually approve people as we get space.  We know

--- a/content/volunteer.md
+++ b/content/volunteer.md
@@ -1,0 +1,52 @@
++++
+title = "Volunteer at CodeRefinery"
++++
+
+## Volunteer at CodeRefinery
+
+CodeRefinery's mission is to enable everyone to be the best
+computational scientist they can be by teaching the most important
+software development skills which usually aren't taught otherwise.
+This is a big task, but together with our volunteer exercise leaders,
+we can do it.
+
+Volunteer to be an **exercise leader** at CodeRefienry, and you will:
+- Get our quick exercise leader training (one hour, see schedule)
+- Have your own team (breakout room) during the course
+- Help keep the team on track.  You are the first line of mentoring
+  and debugging, but you don't need to know everything.
+- Call for others when needed.  We are constantly rotating around
+  breakout rooms anyway.
+
+Don't be intimated.  The amount of initial knowledge you need isn't
+that much: if you have been to a CodeRefinery before, or have some
+basic familiarity with the command line, the some of tools we
+teach, and aren't too afraid of reading error messages, you will do
+fine.  Your job is more to guide people than solve every problem.
+
+**Am I good enough to be a exercise leader?**  If you are asking this
+question, probably you are.  You should have some familiarity with
+git, provide some initial advice on obvious error messages, and
+be able to call us for advanced help when it's needed.
+
+**How do I register as an exercise leader?** Our normal registration
+form has an option for this registration option.
+
+**Teams?**  If you have friends or colleagues you would like to
+mentor, register as part of a team.  First off, if a team has a
+helper, it will almost certainly be accepted.  Second, working
+together makes it much more likely to have a lasting effect.
+
+
+
+### See also
+
+- [Helper
+  introduction](https://coderefinery.github.io/manuals/helper-intro/)
+- [Get more involved in
+  CodeRefinery](https://coderefinery.github.io/manuals/contributing/) -
+  perhaps you want to sponsor workshops or get more involved in
+  organizing a workshop.
+
+
+


### PR DESCRIPTION
- Dedicated to motivating exercise leaders to join, have them bring
  teams, and get more involved in the future.
- I will send this to mentoring mailing lists to recruit people, so it
  should both explain CR and the benefits of helping to society.
- Closes: #45
- Review: general check/revisions, it can continue to be improved.